### PR TITLE
support latest releases, some things changed

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -11,6 +11,11 @@ linux*) platform="ubuntu" ;;
 *) fail "Unsupported platform" ;;
 esac
 
+arch="amd64"
+case $(uname -m) in
+  arm64) arch="arm64"
+esac
+
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
@@ -19,10 +24,17 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
 
 # Download zip file to the download directory
-download_release "$platform" "$ASDF_INSTALL_VERSION" "$release_file"
+download_release "$platform" "$arch" "$ASDF_INSTALL_VERSION" "$release_file"
 
 #  Extract contents of zip file into the download directory
 unzip -qq "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+
+# Versions after dev-2023-02 are zipped up in the CI to keep executable permissions, and then zipped up again by GitHub.
+if [ -f "$ASDF_DOWNLOAD_PATH/dist.zip" ]; then
+  unzip -qq "$ASDF_DOWNLOAD_PATH/dist.zip" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $ASDF_DOWNLOAD_PATH/dist.zip"
+  rm "$ASDF_DOWNLOAD_PATH/dist.zip"
+  mv $ASDF_DOWNLOAD_PATH/dist/* "$ASDF_DOWNLOAD_PATH"
+fi
 
 # Remove the zip file since we don't need to keep it
 rm "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -13,7 +13,7 @@ esac
 
 arch="amd64"
 case $(uname -m) in
-  arm64) arch="arm64"
+arm64) arch="arm64" ;;
 esac
 
 # shellcheck source=../lib/utils.bash
@@ -33,7 +33,7 @@ unzip -qq "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $r
 if [ -f "$ASDF_DOWNLOAD_PATH/dist.zip" ]; then
   unzip -qq "$ASDF_DOWNLOAD_PATH/dist.zip" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $ASDF_DOWNLOAD_PATH/dist.zip"
   rm "$ASDF_DOWNLOAD_PATH/dist.zip"
-  mv $ASDF_DOWNLOAD_PATH/dist/* "$ASDF_DOWNLOAD_PATH"
+  mv "$ASDF_DOWNLOAD_PATH"/dist/* "$ASDF_DOWNLOAD_PATH"
 fi
 
 # Remove the zip file since we don't need to keep it

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -36,12 +36,13 @@ list_all_versions() {
 }
 
 download_release() {
-  local platform version filename url
+  local platform arch version filename url
   platform="$1"
-  version="$2"
-  filename="$3"
+  arch="$2"
+  version="$3"
+  filename="$4"
 
-  url="$GH_REPO/releases/download/${version}/odin-${platform}-amd64-${version}.zip"
+  url="$GH_REPO/releases/download/${version}/odin-${platform}-${arch}-${version}.zip"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
@@ -68,6 +69,10 @@ install_version() {
     mkdir -p "$install_path"
 
     cp -r "$download_path"/* "$install_path"
+
+    # Versions after dev-2024-02 are already executable when downloaded,
+    # to support versions before that release we still `chmod` it.
+
     chmod +x "$install_path/$TOOL_NAME"
 
     local tool_cmd


### PR DESCRIPTION
Latest release changed some stuff about the releases, mainly supporting arm and zipping the release so it retains executable permissions after downloading from GitHub.

Closes #1 
Closes #3 