### PR TITLE
fix download for odin version dev-2024-07

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -34,6 +34,7 @@ if [ -f "$ASDF_DOWNLOAD_PATH/dist.zip" ]; then
   unzip -qq "$ASDF_DOWNLOAD_PATH/dist.zip" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $ASDF_DOWNLOAD_PATH/dist.zip"
   rm "$ASDF_DOWNLOAD_PATH/dist.zip"
   mv "$ASDF_DOWNLOAD_PATH"/dist/* "$ASDF_DOWNLOAD_PATH"
+  rm -rf "$ASDF_DOWNLOAD_PATH"/dist/
 fi
 
 # Remove the zip file since we don't need to keep it


### PR DESCRIPTION
Fix as reported here: https://github.com/jtakakura/asdf-odin/issues/7

Explanation:

This command `mv "$ASDF_DOWNLOAD_PATH"/dist/* "$ASDF_DOWNLOAD_PATH"`, it moves all children to the parent directory and left the `/dist` available and `empty`.

Therefore, removing the `/dist` will eliminate all unwanted side effects.